### PR TITLE
Fix incorrect value of execonfdir

### DIFF
--- a/z/markfunc.go
+++ b/z/markfunc.go
@@ -51,7 +51,7 @@ func cachedir() string {
 }
 
 func confdir() string {
-	dir, _ := os.UserCacheDir()
+	dir, _ := os.UserConfigDir()
 	return dir
 }
 


### PR DESCRIPTION
The confdir() function returned `os.UserCacheDir()` instead of
`os.UserConfigDir()` causing `execonfdir` to incorrectly point to user's
cache directory.