### PR TITLE
fix: protect vars map with RWMutex to eliminate race condition

### DIFF
--- a/bonzai.go
+++ b/bonzai.go
@@ -126,6 +126,7 @@ type Cmd struct {
 	hidden   bool            // see [AsHidden] and [IsHidden]
 	cmdAlias map[string]*Cmd // see [cacheCmdAlias]
 	vars     map[string]*Var // see [Vars]
+	varsMu   sync.RWMutex    // protects vars map
 }
 
 type Vars []Var
@@ -285,8 +286,9 @@ func (x Cmd) WithPersister(a Persister) *Cmd {
 // safe for concurrency but persisters must implement their own
 // file-level locking if shared between multiple processes.
 func (x *Cmd) Get(key string) string {
-	// declaration is mandatory
+	x.varsMu.RLock()
 	v, has := x.vars[key]
+	x.varsMu.RUnlock()
 	if !has {
 		panic(`developer-error: not declared in Vars: ` + key)
 	}
@@ -350,9 +352,9 @@ func (x *Cmd) Get(key string) string {
 // Panics if key was not declared in [Cmd].Vars. Locks the Var in
 // question so safe for concurrency.
 func (x *Cmd) Set(key, value string) {
-
-	// declaration is mandatory
+	x.varsMu.RLock()
 	v, has := x.vars[key]
+	x.varsMu.RUnlock()
 	if !has {
 		panic(`developer-error: not declared in Vars: ` + key)
 	}
@@ -1012,6 +1014,7 @@ func (x *Cmd) resolveInheritedVars() {
 }
 
 func (x *Cmd) cacheVars() {
+	x.varsMu.Lock()
 	x.vars = make(map[string]*Var, len(x.Vars))
 	if x.Persist != nil {
 		x.Persist.Setup()
@@ -1019,18 +1022,24 @@ func (x *Cmd) cacheVars() {
 	for _, v := range x.Vars {
 		if len(v.I) > 0 {
 			x.vars[v.I] = &v
-			// have to put off X assignment until after callers resolved
 			continue
 		}
 		x.vars[v.K] = &v
-		if v.R && len(x.Get(v.K)) == 0 {
-			panic(`required variable not set: ` + v.K)
-		}
-		if v.G != nil {
-			*(v.G) = x.Get(v.K)
-		}
 	}
 	x.Vars = nil
+	x.varsMu.Unlock()
+
+	for k, v := range x.vars {
+		if v.I != "" {
+			continue
+		}
+		if v.R && len(x.Get(k)) == 0 {
+			panic(`required variable not set: ` + k)
+		}
+		if v.G != nil {
+			*(v.G) = x.Get(k)
+		}
+	}
 }
 
 // Path returns the path of commands used to arrive at this command.


### PR DESCRIPTION
Closes #310

Adds `varsMu sync.RWMutex` to `Cmd` to protect the internal `vars map[string]*Var` from concurrent access.

- `Get` and `Set` use `RLock`/`RUnlock` for the map lookup
- `cacheVars` uses `Lock`/`Unlock` while building the map, then unlocks before calling `Get` to avoid deadlock (since `sync.RWMutex` is not reentrant)
- Passes `go test -race`